### PR TITLE
chore: release 2024.12.29

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -7,6 +7,36 @@
 #### @stdext/crypto 0.0.6 (patch)
 
 - feat(crypto): updated readme
+
+#### @stdext/encoding 0.0.6 (patch)
+
+- feat(encoding): updated readme
+
+#### @stdext/http 0.0.6 (patch)
+
+- feat(http): updated readme
+
+#### @stdext/json 0.0.2 (patch)
+
+- feat(json): updated readme
+
+#### @stdext/lexer 0.0.2 (patch)
+
+- feat(lexer): updated readme
+
+#### @stdext/types 0.0.2 (patch)
+
+- feat(types): updated readme
+
+### 2024.12.29
+
+#### @stdext/assert 0.0.2 (patch)
+
+- feat(assert): updated readme
+
+#### @stdext/crypto 0.0.6 (patch)
+
+- feat(crypto): updated readme
 - fix(crypto): Improved throw messages
 
 #### @stdext/encoding 0.0.6 (patch)

--- a/Releases.md
+++ b/Releases.md
@@ -1,63 +1,8 @@
 ### 2024.12.29
 
-#### @stdext/assert 0.0.2 (patch)
+#### @stdext/crypto 0.0.7 (patch)
 
-- feat(assert): updated readme
-
-#### @stdext/crypto 0.0.6 (patch)
-
-- feat(crypto): updated readme
-
-#### @stdext/encoding 0.0.6 (patch)
-
-- feat(encoding): updated readme
-
-#### @stdext/http 0.0.6 (patch)
-
-- feat(http): updated readme
-
-#### @stdext/json 0.0.2 (patch)
-
-- feat(json): updated readme
-
-#### @stdext/lexer 0.0.2 (patch)
-
-- feat(lexer): updated readme
-
-#### @stdext/types 0.0.2 (patch)
-
-- feat(types): updated readme
-
-### 2024.12.29
-
-#### @stdext/assert 0.0.2 (patch)
-
-- feat(assert): updated readme
-
-#### @stdext/crypto 0.0.6 (patch)
-
-- feat(crypto): updated readme
 - fix(crypto): Improved throw messages
-
-#### @stdext/encoding 0.0.6 (patch)
-
-- feat(encoding): updated readme
-
-#### @stdext/http 0.0.6 (patch)
-
-- feat(http): updated readme
-
-#### @stdext/json 0.0.2 (patch)
-
-- feat(json): updated readme
-
-#### @stdext/lexer 0.0.2 (patch)
-
-- feat(lexer): updated readme
-
-#### @stdext/types 0.0.2 (patch)
-
-- feat(types): updated readme
 
 ### 2024.10.15
 

--- a/crypto/deno.json
+++ b/crypto/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "@stdext/crypto",
   "exports": {
     "./hash": "./hash.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|assert|0.0.0|0.0.2|patch|
|crypto|0.0.5|0.0.6|patch|
|encoding|0.0.5|0.0.6|patch|
|http|0.0.5|0.0.6|patch|
|json|0.0.0|0.0.2|patch|
|lexer|0.0.0|0.0.2|patch|
|types|0.0.0|0.0.2|patch|

Please ensure:
- [x] Versions in deno.json files are updated correctly
- [x] Releases.md is updated correctly

The following commits are not recognized. Please handle them manually if necessary:

- [Merge pull request #12 from halvardssm/release-2024-12-29-14-24-33](/halvardssm/stdext/commit/01d30125ab5a6106c4cd7275719024bb5543442a)
- [Update Releases.md](/halvardssm/stdext/commit/5b81399a67a3d81f485a349a32556d092eb2c7a5)
- [Merge pull request #11 from halvardssm/fix/crypto-hash-improved-throws](/halvardssm/stdext/commit/7ce38a6545d7f9cb8918a710eecb5fcdc3c0dd31)
- [Merge branch 'main' of github.com:halvardssm/deno_stdext](/halvardssm/stdext/commit/ddf5d4b12f6cb8fd062f59a0dad871298ff97931)
- [Merge pull request #9 from halvardssm/release-2024-10-15-22-00-44](/halvardssm/stdext/commit/19f47de3f56f6d550f9abf84909ec9b2aef977cb)
- [updated versions](/halvardssm/stdext/commit/e2242904d260a08f1a27715292762bc340f44ece)
- [Added releases and removed changelog](/halvardssm/stdext/commit/a7639e1e84fd302db768f6db392cba4ecb802f6a)
- [Merge pull request #8 from halvardssm/feat/lots](/halvardssm/stdext/commit/89f05c69c2dfe884f76e5f72cbe5d334ad4e0328)
- [updated wasm](/halvardssm/stdext/commit/f73cd0f379900225a10c815acb717fe10368d26b)
- [Refactored wasm and rust workspace, and added jsonpath](/halvardssm/stdext/commit/d1a3e170f3377e93ffb5b0eb0615ed13c8802253)
- [Added helper types](/halvardssm/stdext/commit/fae197dfe433b35d7b8834d230969ea282a6a5b0)
- [Updated wasm and tasks](/halvardssm/stdext/commit/12d39f7f270b1120a00c0980eb59949028c015ca)
- [updated ci scripts according to deno/std](/halvardssm/stdext/commit/a578605f5208ee0e2400d81e166d1cf9d26b4169)
- [Added json package, and added wip of jsonpath](/halvardssm/stdext/commit/445d2a9ed386f972570a1348042b5eaee3d5c056)
- [Added assert package and added basic asserts](/halvardssm/stdext/commit/a87f4b050aadf7091ba2eb1d399495c7c2d425e7)
- [Added lexer package with a general purpose string tokenizer](/halvardssm/stdext/commit/800413be5df63cd4352d53cce4be6dc12d10dbc7)
- [Added types package](/halvardssm/stdext/commit/4f0f57c5133d2557d7004fd23b094078651c2342)
- [Merge pull request #7 from halvardssm/feat/totp](/halvardssm/stdext/commit/76de73f844b867c970cd90361238e73846782381)
- [Updated changelog](/halvardssm/stdext/commit/70de03680e2deb961edcbaaad342f7f6aa1cf556)
- [Deprecated headers and methods](/halvardssm/stdext/commit/6802519cb23673f8d51697748b978647987acc0a)
- [Fixed typings](/halvardssm/stdext/commit/0e12a24bf23b5db1c724be33a501145f15c88db0)
- [Added totp and hotp](/halvardssm/stdext/commit/d24cfc4a181756614361c0470e13ba399b030af8)
- [Updated workspace support](/halvardssm/stdext/commit/c69d9355ceb1d00a389a787b3bcb158cc3ae55b6)
- [added bencmarks](/halvardssm/stdext/commit/81304d165bd900e32bd84f60bba144877edd2f0e)
- [Improved parallelism of tests](/halvardssm/stdext/commit/33f2c43dfcc5a5e5b70b14745c8ffdd25f5badcc)

The following commits have unknown scopes. Please handle them manually if necessary:

- [fix(crypto/hash): removed unused import in test](/halvardssm/stdext/commit/939192277db8bff7be914d4606eecaab6c222a3e)
- [fix(crypto/hash): Improved throw messages](/halvardssm/stdext/commit/c9878d138cee8f772693686d4060196162e40a33)
- [chore(ci): changed token](/halvardssm/stdext/commit/d8cce3b2589a55cee41a02f76fb8aea80a207870)



The following commits are ignored:

- [chore: update versions](/halvardssm/stdext/commit/5f944d0b19235dac609d22f04d086aea6e49b340)
- [chore: fixed version constraints](/halvardssm/stdext/commit/b885f3a1ff872c11258e5bce9f337ea15a1f236d)
- [chore: update versions](/halvardssm/stdext/commit/976e89462a0cc861f94dc398226c7e0ce79ffcee)

---

To make edits to this PR:

```sh
git fetch upstream release-2024-12-29-14-37-39 && git checkout -b release-2024-12-29-14-37-39 upstream/release-2024-12-29-14-37-39
```
